### PR TITLE
Add manual parameter verification notebook for AURO…

### DIFF
--- a/test/Verificacion parametros AURORA_v04.ipynb
+++ b/test/Verificacion parametros AURORA_v04.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6afd754f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from rocketpy import Rocket, SolidMotor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78bbc151",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"parameters_AURORA_v04.json\", \"r\", encoding=\"utf-8-sig\") as f:\n",
+    "    rocket_data = json.load(f)\n",
+    "\n",
+    "airframe = rocket_data[\"airframe\"]\n",
+    "nosecone = rocket_data[\"nosecone\"]\n",
+    "fins = rocket_data[\"fins\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c40df71d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rocketpy.rocket.aero_surface.fins.trapezoidal_fins.TrapezoidalFins at 0x27ccfefadf0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rocket = Rocket(\n",
+    "    radius=airframe[\"radius\"],\n",
+    "    mass=airframe[\"mass\"],\n",
+    "    inertia=tuple(airframe[\"inertia\"]),\n",
+    "    power_on_drag=0.465,\n",
+    "    power_off_drag=0.465,\n",
+    "    center_of_mass_without_motor=airframe[\"center_of_mass_without_motor\"],\n",
+    "    coordinate_system_orientation=airframe[\"coordinate_system_orientation\"]\n",
+    ")\n",
+    "\n",
+    "rocket.add_nose(length=nosecone[\"length\"], kind=nosecone[\"kind\"], position=0)\n",
+    "\n",
+    "rocket.add_trapezoidal_fins(\n",
+    "    n=fins[\"number\"],\n",
+    "    root_chord=fins[\"root_chord\"],\n",
+    "    tip_chord=fins[\"tip_chord\"],\n",
+    "    span=fins[\"span\"],\n",
+    "    position=fins[\"position\"],\n",
+    "    sweep_length=fins[\"sweep_length\"],\n",
+    "    cant_angle=fins[\"cant_angle\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "eb0ca1ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CG   → OR: 1.750 m  |  RPy: 1.750 m  |  diff: 0.0000 m  |  ✓\n",
+      "CP   → OR: 2.950 m  |  RPy: 2.961 m  |  diff: 0.0114 m  |  ✓\n",
+      "Masa → OR: 25.587 kg |  RPy: 25.587 kg |  diff: 0.0000 kg |  ✓\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Valores leídos de OpenRocket\n",
+    "cg_true = 1.75\n",
+    "cp_true = 2.95\n",
+    "mass_true = 25.587\n",
+    "\n",
+    "# Tolerancias\n",
+    "TOL_CG_CP = 0.02\n",
+    "TOL_MASS = 0.2\n",
+    "\n",
+    "# Lo que RocketPy calculó\n",
+    "cg_rpy = rocket.center_of_mass(0)\n",
+    "cp_rpy = rocket.cp_position(0)\n",
+    "mass_rpy = rocket.mass\n",
+    "\n",
+    "print(f\"CG   → OR: {cg_true:.3f} m  |  RPy: {cg_rpy:.3f} m  |  diff: {abs(cg_true - cg_rpy):.4f} m  |  {'✓' if abs(cg_true - cg_rpy) <= TOL_CG_CP else '✗ FALLA'}\")\n",
+    "print(f\"CP   → OR: {cp_true:.3f} m  |  RPy: {cp_rpy:.3f} m  |  diff: {abs(cp_true - cp_rpy):.4f} m  |  {'✓' if abs(cp_true - cp_rpy) <= TOL_CG_CP else '✗ FALLA'}\")\n",
+    "print(f\"Masa → OR: {mass_true:.3f} kg |  RPy: {mass_rpy:.3f} kg |  diff: {abs(mass_true - mass_rpy):.4f} kg |  {'✓' if abs(mass_true - mass_rpy) <= TOL_MASS else '✗ FALLA'}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.20"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
…RA_v04

Add standalone Jupyter notebook for manual verification of AURORA_v04 rocket parameters against OpenRocket reference values.

Replicates the logic of verify_rocket() outside the simulation core, allowing parameter validation without modifying file_simulation.py.

Checks performed:
- CG position (tolerance ±0.02 m)
- CP position (tolerance ±0.02 m)
- Structural mass without motor (tolerance ±0.2 kg)

Reference values (cg_true, cp_true, mass_true) must be read directly from OpenRocket before running the notebook.

## Reference Issue
Closes: N/A
Related:N/A

---

## Objective
Add a standalone manual verification notebook to validate that the AURORA_v04
rocket parameters in the JSON file match the OpenRocket reference model within
predefined tolerances. This ensures parameter traceability before running
flight simulations.

---

## Scope of Changes

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI
- [ ] Other (specify):

### Affected Components
- Module / Package: `test/` (or `notebooks/`)
- Language(s): Python
- Files / Directories modified:
  - `test/Verificacion parametros AURORA_v04.ipynb` ← new file

---

## Validation & Testing

- [ ] Unit tests added or updated
- [x] Manual testing performed
- [ ] Hardware-in-the-loop (HIL)
- [x] Simulation / mock data
- [ ] Not tested (justification required):

**Test procedure:**
1. Open `rocket.ork` in OpenRocket and read CG, CP, and structural mass without motor.
2. Set `cg_true`, `cp_true`, and `mass_true` in the notebook with the values from OpenRocket.
3. Run all cells and confirm all three checks print ✓ within tolerances (±0.02 m for CG/CP, ±0.2 kg for mass).

---

## Limitations & Future Work

### Current Limitations
- Limitation: Reference values (`cg_true`, `cp_true`, `mass_true`) must be entered manually.
  - Reason: OpenRocket does not expose these values programmatically without parsing simulation output.
  - Impact: Verification result depends on the user reading and entering correct values from OpenRocket.

- Limitation: CP tolerance of ±0.02 m may be tight if geometry differs slightly between RocketPy Barrowman and OpenRocket Barrowman implementations.
  - Reason: Minor differences exist between both implementations of the Barrowman equations.
  - Impact: A passing result does not guarantee identical aerodynamic behavior between both tools.

### Deferred / Future Tasks
- [ ] Integrate `verify_rocket()` into `File_simulation.__init__()` to make verification automatic on instantiation.
- [ ] Add `AURORA_v04` to `files_supported` list in `verify_file()`.
- [ ] Replace manual reference values with parsed OpenRocket simulation output.

**Notes:**
Automatic integration is deferred to avoid modifying the simulation core in this PR.
Manual entry of reference values is acceptable for now given the small team size and
controlled workflow.